### PR TITLE
feat: チャットに画像添付機能を追加（マルチモーダル対応）

### DIFF
--- a/chatbot/src/app/api/chat/route.ts
+++ b/chatbot/src/app/api/chat/route.ts
@@ -54,7 +54,7 @@ export async function POST(
     }
 
     // Claude APIを呼び出し
-    const aiResponse = await sendMessage(body.message, conversationHistory)
+    const aiResponse = await sendMessage(body.message, conversationHistory, body.images)
 
     // 新しいメッセージを作成
     const userMessage = {
@@ -62,6 +62,7 @@ export async function POST(
       role: 'user',
       content: body.message,
       createdAt: new Date(),
+      images: body.images,
     }
 
     const assistantMessage = {

--- a/chatbot/src/components/Chat/ChatContainer.tsx
+++ b/chatbot/src/components/Chat/ChatContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { Message, ConversationListItem, Conversation } from '@/types/chat'
+import { Message, ConversationListItem, Conversation, ImageAttachment } from '@/types/chat'
 import MessageList from './MessageList'
 import ChatInput from './ChatInput'
 import ConversationList from './ConversationList'
@@ -53,7 +53,7 @@ export default function ChatContainer() {
   }, [])
 
   // メッセージを送信
-  const handleSendMessage = async (content: string) => {
+  const handleSendMessage = async (content: string, images?: ImageAttachment[]) => {
     setIsLoading(true)
     setError(null)
 
@@ -63,6 +63,7 @@ export default function ChatContainer() {
       role: 'user',
       content,
       createdAt: new Date(),
+      images,
     }
     setMessages((prev) => [...prev, tempUserMessage])
 
@@ -75,6 +76,7 @@ export default function ChatContainer() {
         body: JSON.stringify({
           message: content,
           conversationId: currentConversationId,
+          images,
         }),
       })
 

--- a/chatbot/src/components/Chat/ChatInput.tsx
+++ b/chatbot/src/components/Chat/ChatInput.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, FormEvent, KeyboardEvent } from 'react'
+import { useState, FormEvent, KeyboardEvent, useRef, ChangeEvent } from 'react'
 import Button from '../ui/Button'
+import { ImageAttachment } from '@/types/chat'
 
 interface ChatInputProps {
-  onSend: (message: string) => void
+  onSend: (message: string, images?: ImageAttachment[]) => void
   isLoading?: boolean
   disabled?: boolean
 }
@@ -15,13 +16,67 @@ export default function ChatInput({
   disabled = false,
 }: ChatInputProps) {
   const [message, setMessage] = useState('')
+  const [images, setImages] = useState<ImageAttachment[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
-    if (message.trim() && !isLoading && !disabled) {
-      onSend(message.trim())
+    if ((message.trim() || images.length > 0) && !isLoading && !disabled) {
+      onSend(message.trim(), images.length > 0 ? images : undefined)
       setMessage('')
+      setImages([])
     }
+  }
+
+  const handleImageSelect = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (!files) return
+
+    const newImages: ImageAttachment[] = []
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]
+
+      // ファイルタイプのチェック
+      if (!['image/png', 'image/jpeg', 'image/gif', 'image/webp'].includes(file.type)) {
+        alert(`${file.name}は対応していない形式です。PNG、JPEG、GIF、WebPのみ対応しています。`)
+        continue
+      }
+
+      // Base64エンコード
+      const base64 = await fileToBase64(file)
+
+      newImages.push({
+        data: base64,
+        mediaType: file.type as ImageAttachment['mediaType'],
+        name: file.name,
+      })
+    }
+
+    setImages([...images, ...newImages])
+
+    // ファイル選択をリセット
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  const removeImage = (index: number) => {
+    setImages(images.filter((_, i) => i !== index))
+  }
+
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
+      reader.onload = () => {
+        const result = reader.result as string
+        // data:image/png;base64,... から base64部分のみを取得
+        const base64 = result.split(',')[1]
+        resolve(base64)
+      }
+      reader.onerror = reject
+    })
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -37,31 +92,78 @@ export default function ChatInput({
       onSubmit={handleSubmit}
       className="border-t border-gray-200 dark:border-gray-700 p-4 bg-white dark:bg-gray-900"
     >
-      <div className="flex gap-3 items-end max-w-4xl mx-auto">
-        <div className="flex-1">
-          <textarea
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="メッセージを入力... (Shift+Enterで送信)"
+      <div className="max-w-4xl mx-auto">
+        {/* 画像プレビュー */}
+        {images.length > 0 && (
+          <div className="mb-3 flex flex-wrap gap-2">
+            {images.map((image, index) => (
+              <div key={index} className="relative group">
+                <img
+                  src={`data:${image.mediaType};base64,${image.data}`}
+                  alt={image.name || `画像 ${index + 1}`}
+                  className="h-20 w-20 object-cover rounded-lg border border-gray-300 dark:border-gray-600"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage(index)}
+                  className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                  aria-label="画像を削除"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-3 items-end">
+          <div className="flex-1">
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="メッセージを入力... (Shift+Enterで送信)"
+              disabled={isLoading || disabled}
+              rows={1}
+              className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 dark:disabled:bg-gray-700 disabled:cursor-not-allowed"
+              style={{ minHeight: '48px', maxHeight: '200px' }}
+            />
+          </div>
+
+          {/* 画像添付ボタン */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            multiple
+            onChange={handleImageSelect}
+            className="hidden"
             disabled={isLoading || disabled}
-            rows={1}
-            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 dark:disabled:bg-gray-700 disabled:cursor-not-allowed"
-            style={{ minHeight: '48px', maxHeight: '200px' }}
           />
+          <Button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isLoading || disabled}
+            variant="secondary"
+            className="h-12 px-4"
+            aria-label="画像を添付"
+          >
+            📎
+          </Button>
+
+          <Button
+            type="submit"
+            disabled={(!message.trim() && images.length === 0) || isLoading || disabled}
+            isLoading={isLoading}
+            className="h-12"
+          >
+            送信
+          </Button>
         </div>
-        <Button
-          type="submit"
-          disabled={!message.trim() || isLoading || disabled}
-          isLoading={isLoading}
-          className="h-12"
-        >
-          送信
-        </Button>
+        <p className="text-xs text-gray-500 dark:text-gray-400 text-center mt-2">
+          Shift+Enterで送信 / Enterで改行
+        </p>
       </div>
-      <p className="text-xs text-gray-500 dark:text-gray-400 text-center mt-2">
-        Shift+Enterで送信 / Enterで改行
-      </p>
     </form>
   )
 }

--- a/chatbot/src/components/Chat/MessageItem.tsx
+++ b/chatbot/src/components/Chat/MessageItem.tsx
@@ -8,6 +8,7 @@ interface MessageItemProps {
 
 export default function MessageItem({ message }: MessageItemProps) {
   const isUser = message.role === 'user'
+  const contentText = typeof message.content === 'string' ? message.content : ''
 
   return (
     <div
@@ -25,9 +26,27 @@ export default function MessageItem({ message }: MessageItemProps) {
             {isUser ? 'あなた' : 'AI'}
           </span>
         </div>
-        <p className="whitespace-pre-wrap break-words text-sm md:text-base">
-          {message.content}
-        </p>
+
+        {/* 画像表示 */}
+        {message.images && message.images.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {message.images.map((image, index) => (
+              <img
+                key={index}
+                src={`data:${image.mediaType};base64,${image.data}`}
+                alt={image.name || `画像 ${index + 1}`}
+                className="max-w-xs rounded-lg border border-gray-300 dark:border-gray-600"
+              />
+            ))}
+          </div>
+        )}
+
+        {/* テキスト表示 */}
+        {contentText && (
+          <p className="whitespace-pre-wrap break-words text-sm md:text-base">
+            {contentText}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/chatbot/src/types/chat.ts
+++ b/chatbot/src/types/chat.ts
@@ -1,12 +1,25 @@
 // メッセージの役割
 export type MessageRole = 'user' | 'assistant'
 
+// 画像データ
+export interface ImageAttachment {
+  data: string // Base64エンコードされた画像データ
+  mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+  name?: string
+}
+
+// メッセージコンテンツ（テキストまたは画像）
+export type MessageContent =
+  | string
+  | Array<{ type: 'text'; text: string } | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }>
+
 // 個別メッセージ
 export interface Message {
   id: string
   role: MessageRole
-  content: string
+  content: MessageContent
   createdAt: Date
+  images?: ImageAttachment[] // UI表示用
 }
 
 // 会話
@@ -23,6 +36,7 @@ export interface Conversation {
 export interface ChatRequest {
   message: string
   conversationId?: string
+  images?: ImageAttachment[]
 }
 
 // チャットAPIレスポンス


### PR DESCRIPTION
## 概要
チャットボットに画像添付機能を追加し、Claude APIのマルチモーダル機能を活用して画像とテキストを同時に送信できるようにしました。

## 実装内容
- 📎 画像添付ボタンをChatInputに追加
- 🖼️ 複数画像のプレビュー表示機能
- ✅ PNG、JPEG、GIF、WebP形式に対応
- 🔤 Base64エンコードでClaude APIに送信
- 💬 メッセージ履歴で画像を表示

Closes #3

Generated with [Claude Code](https://claude.ai/code)